### PR TITLE
127   reparar funcionamiento de status de evidencias

### DIFF
--- a/src/pages/uploadEvidence.jsx
+++ b/src/pages/uploadEvidence.jsx
@@ -54,8 +54,8 @@ const UploadEvidence = () => {
           // Ordena por fecha y hora más reciente
           if (response.data.evidence.status && response.data.evidence.status.length > 0) {
             response.data.evidence.status.sort((a, b) => {
-              const dateA = new Date(a.created_at);
-              const dateB = new Date(b.created_at);
+              const dateA = new Date(a.created_at ?? a.status_date ?? 0);
+              const dateB = new Date(b.created_at ?? b.status_date ?? 0);
               return dateB - dateA;
             });
           }

--- a/src/pages/uploadEvidence.jsx
+++ b/src/pages/uploadEvidence.jsx
@@ -481,14 +481,73 @@ const UploadEvidence = () => {
                 </div>
               )}
               {/* Información de la evidencia */}
-              <h2 className="text-[25px] font-light text-black font-['Open_Sans'] mb-4 self-start">
-                Proceso: {evidence.process.process_name}
-              </h2>
-              <h2 className="text-[25px] font-light text-black font-['Open_Sans'] mb-4 self-start">
-                {evidence.standard.section.category.category_name}/
-                {evidence.standard.section.section_name}/
-                {evidence.standard.standard_name}
-              </h2>
+              <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-3 mt-4 mb-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="bg-[#004A98] p-1.5 rounded">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-white" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                  <h2 className="text-lg font-bold text-gray-800">Información de la Evidencia</h2>
+                </div>
+                
+                <div className="space-y-3">
+                  {/* Proceso */}
+                  <div className="flex items-center gap-2 p-2 bg-blue-50 rounded border border-blue-200">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-[#004A98]" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                    </svg>
+                    <div>
+                      <span className="text-xs font-medium text-gray-600">Proceso:</span>
+                      <span className="ml-1 font-semibold text-gray-900 text-sm">{evidence.process.process_name}</span>
+                    </div>
+                  </div>
+
+                  {/* Jerarquía de la evidencia */}
+                  <div>
+                    <div className="flex items-center gap-1 text-xs text-gray-600 mb-1.5">
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+                      </svg>
+                      <span className="font-medium">Ubicación:</span>
+                    </div>
+                    
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <div className="flex items-center gap-1.5 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-[#004A98]" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 0h8v12H6V4z" clipRule="evenodd" />
+                        </svg>
+                        <span className="text-xs text-gray-500">Categoría</span>
+                        <span className="font-semibold text-gray-900 text-xs">{evidence.standard.section.category.category_name}</span>
+                      </div>
+                      
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+                      </svg>
+                      
+                      <div className="flex items-center gap-1.5 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-[#004A98]" viewBox="0 0 20 20" fill="currentColor">
+                          <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span className="text-xs text-gray-500">Indicador</span>
+                        <span className="font-semibold text-gray-900 text-xs">{evidence.standard.section.section_name}</span>
+                      </div>
+                      
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+                      </svg>
+                      
+                      <div className="flex items-center gap-1.5 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-[#004A98]" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                        </svg>
+                        <span className="text-xs text-gray-500">Criterio</span>
+                        <span className="font-semibold text-gray-900 text-xs">{evidence.standard.standard_name}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <p className="text-black text-lg font-semibold">Justificación</p>
               {/* Editor integrado de CKEditor (en EditorCacei.jsx) */}
               <EditorCacei setJustification={setJustification} value={justification} readOnly={user?.user_rpe !== evidence.user_rpe || isLocked} />

--- a/src/pages/uploadEvidence.jsx
+++ b/src/pages/uploadEvidence.jsx
@@ -28,6 +28,7 @@ const UploadEvidence = () => {
 
   const navigate = useNavigate();
 
+  // Obtener información del usuario
   useEffect(() => {
     const fetchUser = async () => {
       try {
@@ -40,6 +41,7 @@ const UploadEvidence = () => {
     fetchUser();
   }, []);
 
+  // Obtener información de la evidencia
   useEffect(() => {
     if (evidence_id) {
       api.get(`api/evidences/${evidence_id}`).then(
@@ -100,6 +102,7 @@ const UploadEvidence = () => {
     }
   }, [evidence_id, user]);
 
+  // ¿Revisa si el usuario tiene asignaciones?
   useEffect(() => {
     async function fetchData() {
       try {
@@ -117,6 +120,7 @@ const UploadEvidence = () => {
     fetchData();
   }, []);
 
+  // ¿Obtiene las evidencias transversales?
   useEffect(() => {
   if (evidence?.standard?.is_transversal) {
     const fetchRelatedEvidences = async () => {
@@ -131,6 +135,7 @@ const UploadEvidence = () => {
   }
 }, [evidence]);
 
+  // Revisa la información del archivo a subir ¿¡¿Esto no lo hacía ya backend?!?!
   const handleFileChange = (event) => {
     const allowedExtensions = ['rar', 'zip', 'xls', 'xlsx', 'csv', 'pdf', 'doc', 'docx', 'csv'];
     const maxFileSize = 50 * 1024 * 1024;

--- a/src/pages/uploadEvidence.jsx
+++ b/src/pages/uploadEvidence.jsx
@@ -169,6 +169,7 @@ const UploadEvidence = () => {
     refInputFiles.current.value = "";
   };
 
+  // Sube los archivos y la justificación
   const handleUpload = async () => {
     if (isFinished) {
       alert("No se pueden subir archivos porque el proceso ha finalizado");
@@ -328,6 +329,8 @@ const UploadEvidence = () => {
       alert(`Error al subir archivo: ${error.response?.data?.message || error.message}`);
     }
   };
+
+  // Elimina un archivo subido
   const handleDeleteUploadedFile = async (fileId) => {
     if (!window.confirm("¿Seguro que quieres eliminar este archivo?")) return;
     setIsLocked(true);
@@ -346,10 +349,14 @@ const UploadEvidence = () => {
     setIsLocked(false);
   };
 
+  // Elimina el archivo a subir
   const handleRemoveFile = (fileName) => {
     setFiles((prev) => prev.filter((file) => file.name !== fileName));
   };
 
+  // Obtiene la clase CSS según el estado
+  
+  
   const getEstadoClass = (estado) => {
     switch (estado) {
       case "NO CARGADA":
@@ -365,6 +372,7 @@ const UploadEvidence = () => {
     }
   };
 
+  // Obtiene el ícono (del archivo a subir) según la extensión
   const getIcon = (name) => {
     const extension = name.split('.').pop();
 
@@ -374,6 +382,7 @@ const UploadEvidence = () => {
 
   };
 
+  // Revisa si el usuario puede ver la página
   const canViewPage = () => {
     if (!user || !evidence) return false;
 
@@ -387,23 +396,29 @@ const UploadEvidence = () => {
     return false;
   };
 
+  // Revisa si actualmente el usuario puede ver la página
   useEffect(() => {
     if (user && evidence && !canViewPage()) {
       navigate("/mainmenu");
     }
   }, [user, evidence]);
 
+  // Revisa si el proceso ha finalizado (y bloquear interacciones)
   useEffect(() => {
     if (Finished == 'true'){
       setIsFinished(true);
     }
   })
 
+  // HTML ------------------------------------------------------------------------------------------------------------------------------
   return (
     <>
       <AppHeader />
       <SubHeading />
+
       <div className="h-fit p-10 flex justify-around items-stretch relative gap-6" style={{ background: "linear-gradient(180deg, #e1e5eb 0%, #FFF 50%)" }}>
+        
+        {/* Cuadro de asignaciones */}
         <div className="w-1/4 bg-white rounded-xl shadow-md border border-gray-100 overflow-hidden">
           <div className="bg-primary1 p-3">
             <h2 className="text-lg font-semibold text-white text-center">Mis asignaciones</h2>
@@ -412,8 +427,9 @@ const UploadEvidence = () => {
             <div className="relative min-h-[200px]" style={{ paddingTop: "10px" }}>
               <LoadingSpinner />
             </div>
-          ) : asignaciones.length > 0 ? (
+          ) : asignaciones.length > 0 ? ( 
             <div className="divide-y divide-gray-100 max-h-[600px] overflow-y-auto">
+              {/* Lista de asignaciones */}
               {asignaciones.map((item, index) => (
                 <Link
                   key={index}
@@ -432,7 +448,12 @@ const UploadEvidence = () => {
                     }`}>{item.criterio}</p>
                     <span className={`px-2 py-0.5 rounded-full text-sm font-medium whitespace-nowrap ${getEstadoClass(item.estado)}`}>
                       {item.estado}
+                      {/*DEBUGGING*/}
+                      <script>
+                        console.log("item.estado:", item.estado);
+                      </script>
                     </span>
+                    
                   </div>
                 </Link>
               ))}
@@ -446,6 +467,7 @@ const UploadEvidence = () => {
             </div>
           )}
         </div>
+        {/* Cuadro donde interactúa con la evidencia */}
         {evidence_id && evidence ? (
           <div className="bg-white p-6 rounded-xl shadow-md flex flex-wrap flex-row w-3/4 min-h-[500px]">
             <div className="flex flex-col flex-1 mr-10 w-1/2">
@@ -458,6 +480,7 @@ const UploadEvidence = () => {
                   <p>No se pueden subir más evidencias porque el proceso de evaluación ha concluido.</p>
                 </div>
               )}
+              {/* Información de la evidencia */}
               <h2 className="text-[25px] font-light text-black font-['Open_Sans'] mb-4 self-start">
                 Proceso: {evidence.process.process_name}
               </h2>
@@ -467,6 +490,7 @@ const UploadEvidence = () => {
                 {evidence.standard.standard_name}
               </h2>
               <p className="text-black text-lg font-semibold">Justificación</p>
+              {/* Editor integrado de CKEditor (en EditorCacei.jsx) */}
               <EditorCacei setJustification={setJustification} value={justification} readOnly={user?.user_rpe !== evidence.user_rpe || isLocked} />
               {user?.user_rpe === evidence.user_rpe && (
                 <div className="mt-4 flex">
@@ -484,6 +508,7 @@ const UploadEvidence = () => {
                   <div className="w-1/10"><FileQuestion size={50} onClick={() => { setShowCriteriaGuide(true) }} /></div>
                 </div>
               )}
+              {/* Para subir archivos */}
               {files && files.map((file) => (
                 <div className="mt-4 flex items-center justify-between gap-2 p-2 border rounded bg-gray-100 text-gray-600">
                   <span className="text-2xl">{getIcon(file.name)}</span>
@@ -503,6 +528,7 @@ const UploadEvidence = () => {
                 <button className="bg-[#004A98] text-white px-20 py-2 mt-5 mx-auto rounded-full" onClick={handleUpload} disabled={isLocked}>Guardar</button>
               )}
             </div>
+            {/* Cuadro de revisión (la info del revisor, pues) */}
             <div className="w-1/2 overflow-y-auto max-h-[700px]">
               <h1 className="text-[40px] font-semibold text-black font-['Open_Sans'] mt-2 self-start">
                 Revisión
@@ -532,10 +558,16 @@ const UploadEvidence = () => {
                   </div>
                   <div className="space-y-3">
                     <div>
+                      {/* Obtiene el estado de la revisión */}
                       <p className="text-sm font-medium text-gray-600 mb-1">Estado de la revisión</p>
                       <p className={`inline-block px-4 py-1.5 rounded-full text-sm font-medium ${getEstadoClass(item.status_description)}`}>
                         {item.status_description}
+                        {/*DEBUGGING*/}
+                        <script>
+                        console.log("item.status_description:", item.status_description);
+                        </script>
                       </p>
+                      
                     </div>
                     <div>
                       <p className="text-sm font-medium text-gray-600 mb-1">Retroalimentación</p>


### PR DESCRIPTION
Realmente solo se hicieron comentarios en este PR. El error está en Backend, el cual ya tambien hay PR listo, corrigiendo el error de no tomar el estatus correcto.

Para más información del problema que se resolvió:

- En el cuadro para seleccionar las asignaciones, estaba incorrecto, solo estaba bien la primera asignación y las demás mostraban "PENDIENTE", esto debido a que es el valor por defecto que manda el _fetch_ en Backend
- En el cuadro de información de revisor si mostraba la información correcta, en base a esto se corrigió el anterior punto